### PR TITLE
add MITProfessionalX+ENX_Fake to blacklist

### DIFF
--- a/courses.txt
+++ b/courses.txt
@@ -1,1 +1,1 @@
-
+MITProfessionalX+ENX_Fake


### PR DESCRIPTION
#### What are the relevant tickets?

fixes https://github.com/mitodl/open-discussions/issues/2490

#### What's this PR do?

adds the MITx course `MITProfessionalX+ENX_Fake` "MITPE Fake Shell" to the blacklist

#### How should this be manually tested?

After https://github.com/mitodl/open-discussions/pull/2519 merges, see if `MITProfessionalX+ENX_Fake` is removed from the index. 