### PR TITLE
remove test courses on edX.org

### DIFF
--- a/courses.txt
+++ b/courses.txt
@@ -1,1 +1,6 @@
 MITProfessionalX+ENX_Fake
+MITx+fbe.123x
+MITx+MEDIA.101x
+MITx+MITx.001x
+MITx+ET.102x
+MITx+MITTEST


### PR DESCRIPTION
I don't know why these courses would be exposed in the edX course feed, but somehow they arrived in our index.