### PR TITLE
block courses without a course number

### DIFF
--- a/courses.txt
+++ b/courses.txt
@@ -1,3 +1,4 @@
+.
 MITProfessionalX+ENX_Fake
 MITx+fbe.123x
 MITx+MEDIA.101x


### PR DESCRIPTION
fixes https://github.com/mitodl/open-discussions/issues/3336

when ocw-data-parser parses something that isn't a course, it gets a course number of `.`